### PR TITLE
Feature/recommendation diversity and explainability

### DIFF
--- a/app/api/v1/endpoints/recommendations.py
+++ b/app/api/v1/endpoints/recommendations.py
@@ -136,6 +136,7 @@ async def calculate_collaborative_scores(
 @router.get("",response_model=RecommendationResponse)
 async def get_my_recommendations(
     top_k: int = Query(10, ge=1, le=100, description="추천 영화 개수"),
+    apply_mmr: bool = Query(True, description="MMR 다양성 보장 적용 여부"),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db)
 ):
@@ -144,6 +145,7 @@ async def get_my_recommendations(
     로그인한 사용자 맞춤 추천 (Redis 캐싱)
     
     - top_k : 추천할 영화 개수 (기본 10개)
+    - apply_mmr : MMR 다양성 보정 적용 여부 (default True)
     """
     
     user_id = current_user.id
@@ -172,23 +174,33 @@ async def get_my_recommendations(
     
     # 전략 선택
     rec = get_recommender()
+    strategy = ""
+    reason_template = ""
     if rating_count == 0 :
         # 신규 사용자용
         logger.info(f"인기 영화 추천: user_id={user_id}")
+        strategy = "popular"
+        reason_template = "많은 사양자가 높게 평가한 인기영화"
+        
         movie_stats = await get_movie_stats(db)
-        recommendations = rec.recommend_popular(movie_stats, top_k)
+        recommendations = rec.recommend_popular(movie_stats, top_k * 2) # MMR을 위해 top_k의 2배를 지정
         
     elif rating_count <= 4:
         # 초기 사용자: CBF 기반
-        logger.info(f"CBF 기반 추천: user_id = {user_id}, rating_count={rating_count}") 
+        logger.info(f"CBF 기반 추천: user_id = {user_id}, rating_count={rating_count}")
+        strategy = "content_based"
+        reason_template = "종하사는 영화와 유사한 장르"
+        
         user_rated_movies = await get_user_rated_movies_with_genres(db, user_id)
         rated_movie_ids = [r["movie_id"] for r in user_rated_movies]
         candiate_movies = await get_candidate_movies_with_genres(db, rated_movie_ids)
-        recommendations = rec.recommend_content_based(user_rated_movies, candiate_movies, top_k)
+        recommendations = rec.recommend_content_based(user_rated_movies, candiate_movies, top_k * 2)
     
     else :
-        # 그외 사용자
+        # 그외 사용자 (충분한 평점을 갖고 있는 경우)
         logger.info(f"하이브리드 추천: user_id = {user_id}, rating_count = {rating_count}")
+        strategy = "hybrid"
+        reason_template = "당신의 평점 패턴 기반 개인화 추천"
         rated_movie_ids = [r.movie_id for r in user_ratings]
         candidate_movie_ids = [mid for mid in all_movie_ids if mid not in rated_movie_ids]
         
@@ -200,10 +212,29 @@ async def get_my_recommendations(
             user_id,
             candidate_movie_ids,
             cf_scores,
-            top_k,
+            top_k * 2,
             ncf_weight=0.7
             
         )
+        
+    if apply_mmr and len(recommendations) > top_k:
+        # 장르 정보를 추가
+        movie_ids_for_genres = [r["movie_id"] for r in recommendations]
+        result = await db.execute(
+            select(Movie.id, Movie.genres)
+            .where(Movie.id.in_(movie_ids_for_genres))
+        )
+        genres_map = {movie_id: genres for movie_id, genres in result.fetchall()}
+        
+        # recommendations에 장르 추가
+        
+        for rec_item in recommendations:
+            rec_item["genres"] = genres_map.get(rec_item["movie_id"],"")
+            
+        # MMR 적용
+        recommendations = rec.apply_mmr_diversity(recommendations, top_k, lambda_param=0.7)
+    else :
+        recommendations = recommendations[:top_k]
         
     # 영화 정보 조회
     movie_ids = [r['movie_id'] for r in recommendations]
@@ -223,19 +254,22 @@ async def get_my_recommendations(
                 RecommendationItem(
                     movie_id=movie_id,
                     title=movie.title,
-                    predicted_rating=round(rec_item["predicted_rating"],2)
+                    predicted_rating=round(rec_item["predicted_rating"],2),
+                    reason=reason_template,
+                    genres=movie.genres
                 )
             )
     
     # Res 데이터 생성
     response_data = {
         "user_id": user_id,
+        "strategy": strategy,
         "recommendations": [item.model_dump() for item in response_items]
     }
     
     await redis_client.set_recommendation_cache(user_id, response_data, ttl=3600)
     
-    logger.info(f"추천 완료 및 캐싱 : user_id={user_id}, count={len(response_items)}")
+    logger.info(f"추천 완료 및 캐싱 : user_id={user_id}, count={len(response_items)}, strategy={strategy}")
     
     return RecommendationResponse(**response_data)
 
@@ -280,12 +314,14 @@ async def get_recommendations_by_user_id(
                 RecommendationItem(
                     movie_id=movie.id,
                     title=movie.title,
-                    predicted_rating=round(rec_item['predicted_rating'], 2)
+                    predicted_rating=round(rec_item['predicted_rating'], 2),
+                    genres=movie.genres
                 )
             )
     
     return RecommendationResponse(
         user_id=user_id,
+        strategy="ncf",
         recommendations=response_items
     )
 

--- a/app/ml/inference/predictor.py
+++ b/app/ml/inference/predictor.py
@@ -163,7 +163,94 @@ class MovieRecommender:
             for movie_id, rating in sorted_movies
         ]
         
+    
+    def apply_mmr_diversity(
+        self,
+        candidates: List[Dict],
+        top_k: int = 10,
+        lambda_param: float = 0.7
+    ) -> List[Dict]:
+        """
+        MMR (Maximal Marginal Relevance)로 다양성을 보정함
+        -> 최대 한계 관련성(Maximum Marginal Relevance, MMR) 검색 방식은 유사성과 다양성의 균형을 맞추어 검색 결과의 품질을 향상시키는 알고리즘
         
+        Args:
+            candidates: [{"movie_id":int, "predicted_rating": float, "genres":str}, ...]
+            top_k: 최종 선택할 개수
+            lambda_param: 관련성 vs 다양성의 균형 (0 - 1, 높을수록 관련성 우선)
+        
+        Returns:
+            다양성이 보정된 추천 목록
+        """
+        if not candidates or len(candidates) <= top_k:
+            return candidates[:top_k]
+        
+        # 장르 파싱 헬퍼
+        def parse_genres(genres_str):
+            if  not genres_str:
+                return set()
+            return set(genres_str.split(","))
+        
+        # 자카드 유사도 계산
+        def jaccard_similarity(genres1, genres2):
+            if not genres1 or not genres2:
+                return 0.0
+            intersection = len(genres1 & genres2)
+            union = len(genres1 | genres2)
+            return intersection / union if union > 0 else 0.0
+        
+        # 후보들의 장르 파싱
+        for cand in candidates:
+            cand["_genres_set"] = parse_genres(cand.get("genres",""))
+            
+        # 점수 정규화 (0-1)
+        scores = [c["predicted_rating"] for c in candidates]
+        min_score, max_score = min(scores), max(scores)
+        score_range = max_score - min_score if max_score > min_score else 1.0
+        
+        for cand in candidates:
+            cand["_norm_score"] = (cand["predicted_rating"] - min_score) / score_range
+    
+        # MMR 선택
+        selected = []
+        remaining_indices = list(range(len(candidates)))
+        
+        # 첫 번째는 최고 점수
+        best_idx = max(remaining_indices, key=lambda i: candidates[i]['_norm_score'])
+        selected.append(candidates[best_idx])
+        remaining_indices.remove(best_idx)
+        
+        # 나머지 선택
+        while len(selected) < top_k and remaining_indices:
+            mmr_scores = []
+            
+            for idx in remaining_indices:
+                cand = candidates[idx]
+                
+                # Relevance (관련성)
+                relevance = cand['_norm_score']
+                
+                # Max similarity (이미 선택된 것들과의 최대 유사도)
+                max_sim = max(
+                    jaccard_similarity(cand['_genres_set'], s['_genres_set'])
+                    for s in selected
+                )
+                
+                # MMR 점수
+                mmr = lambda_param * relevance - (1 - lambda_param) * max_sim
+                mmr_scores.append((idx, mmr))
+            
+            # 최고 MMR 선택
+            best_idx, _ = max(mmr_scores, key=lambda x: x[1])
+            selected.append(candidates[best_idx])
+            remaining_indices.remove(best_idx)
+        
+        # 임시 필드 제거
+        for item in selected:
+            item.pop('_genres_set', None)
+            item.pop('_norm_score', None)
+        
+        return selected
     def recommend_popular(
         self,
         movie_stats: List[Dict], # [{"movie_id": int, "avg_rating": float, "rating_count": int}, ...]

--- a/app/schemas/recommendation.py
+++ b/app/schemas/recommendation.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import List
+from typing import List, Optional
 
 class PredictionRequest(BaseModel):
     user_id: int = Field(..., description="사용자 ID")
@@ -17,9 +17,11 @@ class RecommendationItem(BaseModel):
     movie_id: int
     title: str
     predicted_rating: float
-    
+    reason: Optional[str] = Field(None, description="추천 이유")
+    genres: Optional[str] = Field(None, description="장르")
 class RecommendationResponse(BaseModel):
     user_id: int
+    strategy: str = Field(..., description="추천 전략 (popular/content_based/hybrid/ncf)")
     recommendations: List[RecommendationItem]
     
     

--- a/tests/test_hybrid_recommendations.py
+++ b/tests/test_hybrid_recommendations.py
@@ -48,6 +48,21 @@ async def test_recommedation_strategy_popular():
         avg_rating = sum(r["predicted_rating"] for r in data["recommendations"]) / len((data["recommendations"]))
         assert avg_rating >= 7.0
 
+        # 새로운 필드 검증
+        assert "strategy" in data
+        assert data["strategy"] == "popular"
+        
+        # 첫 번째 추천 아이템 검증
+        first_rec = data["recommendations"][0]
+        assert "movie_id" in first_rec
+        assert "title" in first_rec
+        assert "predicted_rating" in first_rec
+        # reason, genres는 Optional이므로 있으면 확인
+        if "reason" in first_rec:
+            assert isinstance(first_rec["reason"], str)
+        if "genres" in first_rec:
+            assert isinstance(first_rec["genres"], str)
+            
 @pytest.mark.asyncio
 async def test_recommendation_strategy_content_based():
     async with AsyncClient(
@@ -92,6 +107,11 @@ async def test_recommendation_strategy_content_based():
         
         assert "recommendations" in data
         assert len(data["recommendations"]) > 0
+        
+        # 새로운 필드 검증
+        assert "strategy" in data
+        assert data["strategy"] == "content_based"
+        
 
 @pytest.mark.asyncio
 async def test_recommendation_strategy_hybrid():
@@ -141,3 +161,8 @@ async def test_recommendation_strategy_hybrid():
         
         assert "recommendations" in data
         assert len(data["recommendations"]) > 0
+
+        # 새로운 필드 검증
+        assert "strategy" in data
+        assert data["strategy"] == "hybrid"
+        


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #27 

## 📝 변경 내용

### 주요 변경사항
- MMR 다양성 보정: Jaccard 유사도 기반 장르 다양성 알고리즘 적용
- 추천 이유 표시: 전략별 추천 메시지 제공
- 스키마 확장: strategy, reason, genres 필드 추가

MMR 알고리즘 및 관련성 / 다양성 비율
```python
# 관련성과 다양성의 균형
mmr_score = λ × relevance - (1-λ) × max_similarity

# lambda_param=0.7 (관련성 70%, 다양성 30%)
recommendations = rec.apply_mmr_diversity(candidates, top_k, lambda_param=0.7)
```

## 🧪 테스트 결과
```bash
# 테스트 명령어
pytest tests/test_hybrid_recommendations.py -v

```

## ✅ 체크리스트
- [x] 로컬 환경 테스트 완료
- [x] API 엔드포인트 동작 확인
- [x] 테스트 코드 작성 및 통과 (3/3)
- [x] Docker 환경 재빌드 확인
- [ ] 문서 업데이트 (README)

## 💬 추가 설명
- `app/schemas/recommendation.py` (스키마 확장)
- `app/ml/inference/predictor.py` (MMR 추가)
- `app/api/v1/endpoints/recommendations.py` (추천 이유 + MMR 적용)
- `tests/test_hybrid_recommendations.py` (테스트 업데이트)