### PR TITLE
Feature/prometheus monitoring #31

### DIFF
--- a/app/api/v1/endpoints/ratings.py
+++ b/app/api/v1/endpoints/ratings.py
@@ -12,7 +12,7 @@ from app.api.dependencies import get_current_user
 from app.core.redis_client import redis_client # 260320 추가
 from app.services.movie_stats_updater import run_update_movie_stats #260323추가
 import logging # 260320 추가
-
+from app.core.metrics import metrics
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
@@ -75,6 +75,8 @@ async def create_rating(
     # 평점 등록 후 캐시 무효화
     await redis_client.invalidate_user_cache(current_user.id)
     logger.info(f" 캐시 무효화: user_id={current_user.id}")
+    
+    metrics.rating_operations.labels(operation="create").inc()
     
     # movie_stats 갱신 (BackgroundTask)
     background_tasks.add_task(run_update_movie_stats, rating_data.movie_id)
@@ -184,6 +186,8 @@ async def update_rating(
     await redis_client.invalidate_user_cache(current_user.id)
     logger.info(f"🗑️ 캐시 무효화: user_id={current_user.id}")
     
+    metrics.rating_operations.labels(operation="update").inc()
+    
     # movie_stats 갱신(BackgroundTask)
     background_tasks.add_task(run_update_movie_stats, movie_id)
     
@@ -225,6 +229,7 @@ async def delete_rating(
     await redis_client.invalidate_user_cache(current_user.id)
     logger.info(f"🗑️ 캐시 무효화: user_id={current_user.id}")
     
+    metrics.rating_operations.labels(operation="delete").inc()
     # movie_stats 갱신(BackgroundTask)
     background_tasks.add_task(run_update_movie_stats, movie_id)
     

--- a/app/api/v1/endpoints/recommendations.py
+++ b/app/api/v1/endpoints/recommendations.py
@@ -4,6 +4,8 @@ from sqlalchemy import select, func #260322추가
 from typing import List, Dict #260322추가
 
 from app.core.database import get_db
+from app.core.metrics import metrics # 260325 추가
+
 from app.models.movie import Movie
 from app.models.user_rating import UserRating # 260320추가
 # from app.models.training import TrainingRating #260322추가
@@ -21,6 +23,9 @@ from app.schemas.recommendation import (
 from app.api.dependencies import get_current_user # 260320추가
 from app.core.redis_client import redis_client # 260320추가
 import logging # 260320추가
+import time
+
+
 
 logger = logging.getLogger(__name__)
 
@@ -157,6 +162,7 @@ async def get_my_recommendations(
         return RecommendationResponse(**cached_data)
     
     logger.info(f" 새로운 추천 생성 중 : user_id={user_id}")
+    start_time = time.perf_counter()
     
     # 사용자 평점 개수 확인
     result = await db.execute(
@@ -269,6 +275,10 @@ async def get_my_recommendations(
     
     await redis_client.set_recommendation_cache(user_id, response_data, ttl=3600)
     
+    elapsed = time.perf_counter() - start_time
+    metrics.recommendation_latency.labels(strategy=strategy).observe(elapsed)
+    metrics.recommendation_requests.labels(strategy=strategy).inc()
+    logger.info(f"추천 생성 소요 시간: {elapsed * 1000: .1f}ms, strategy={strategy}")
     logger.info(f"추천 완료 및 캐싱 : user_id={user_id}, count={len(response_items)}, strategy={strategy}")
     
     return RecommendationResponse(**response_data)

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -1,0 +1,78 @@
+"""
+Prometheus 메트릭을 정의하는 공간
+
+사용법: 
+    from app.core.metrics import metrics
+    
+    metrics.recommendation_latency.observe(0.123)
+    metrics.cache_hits.inc()
+    
+"""
+
+from prometheus_client import Counter, Histogram, Gauge, Info
+
+class AppMetrics:
+    """
+    앱 전체 메트릭을 관리하는 클래스
+    """
+    
+    def __init__(self):
+        #추천 API
+        self.recommendation_requests = Counter(
+            "recommendation_requests_total",
+            "TOtal recommedation API requests",
+            ["strategy"] # popular, content based, hybrid
+        )
+        
+        self.recommendation_latency = Histogram(
+            "recommendation_latency_seconds",
+            "Recommendation generation latency",
+            ["strategy"],
+            buckets=[0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]
+        )
+        
+        # Redis 캐시
+        self.cache_hits = Counter(
+            "redis_cache_hits_total",
+            "Total Redis cache hits"
+        )
+        
+        self.cache_misses = Counter(
+            "redis_cache_misses_total",
+            "Total Redis cache misses"
+        )
+        
+        # Model Predict
+        self.model_inference_latency = Histogram(
+            "model_inference_latency_seconds",
+            "NCF model inference latency",
+            buckets=[0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0]
+        )
+        
+        # 평점
+        self.rating_operations = Counter(
+            "rating_operations_total",
+            "Total rating operations",
+            ["operation"] # create, update, delete
+        )
+        
+        # active user
+        self.active_users = Gauge(
+            "active_users_current",
+            "Currently active users (approximate)"
+        )
+        
+        # 앱 정보
+        self.app_info = Info(
+            "Bob_movie_app",
+            "Application infomation"
+        )
+        
+        self.app_info.info({
+            "version": "2.2.0",
+            "model": "NCF",
+            "framework": "FastAPI"
+        })
+        
+        
+metrics = AppMetrics()

--- a/app/core/redis_client.py
+++ b/app/core/redis_client.py
@@ -5,6 +5,8 @@ from typing import Optional
 import json
 import logging
 import time
+from app.core.metrics import metrics # 260325 추가
+
 logger = logging.getLogger(__name__)
 
 class RedisClient:
@@ -61,8 +63,10 @@ class RedisClient:
             
             if data:
                 logger.info(f"캐싱 히트 : user_id = {user_id}")
+                metrics.cache_hits.inc()
                 return json.loads(data)
             logger.info(f"캐싱 미스 : user_id={user_id}")
+            metrics.cache_misses.inc()
             return None
         except Exception as e :
             logger.error(f"캐싱 조회 오류 : {e}")

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,8 @@ from app.ml.inference.predictor import MovieRecommender
 from app.core.redis_client import redis_client
 from app.middleware.request_logging import RequestLoggingMiddleware  #260324 추가
 
+from prometheus_client import generate_latest, CONTENT_TYPE_LATEST #260325 추가
+from starlette.responses import Response
 setup_logging(log_level="DEBUG" if settings.DEBUG else "INFO")
 logger = logging.getLogger(__name__)
 
@@ -106,3 +108,9 @@ async def health_check():
         "redis": "connected" if redis_connected else "disconnected"
     }
     
+@app.get("/metrics")
+async def prometheus_metrics():
+    return Response(
+        content=generate_latest(),
+        media_type=CONTENT_TYPE_LATEST
+    )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,5 +41,42 @@ services:
       - "6379:6379"
     restart: unless-stopped
 
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: bob_prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=15d"
+      - "--web.enable-lifecycle"
+    depends_on:
+      - app
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: bob_grafana
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: bobgrafana
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_SERVER_ROOT_URL: http://localhost:3000
+    volumes:
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./monitoring/grafana/dashboards:/etc/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+
 volumes:
   mysql_data:
+  prometheus_data:
+  grafana_data:

--- a/monitoring/grafana/dashboards/bob_dashboard.json
+++ b/monitoring/grafana/dashboards/bob_dashboard.json
@@ -1,0 +1,171 @@
+{
+  "title": "Bob Movie Service",
+  "uid": "bob-movie-dashboard",
+  "timezone": "Asia/Seoul",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "10s",
+  "panels": [
+    {
+      "id": 1,
+      "title": "추천 API 요청 수 (전략별)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "rate(recommendation_requests_total[5m])",
+          "legendFormat": "{{ strategy }}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": { "mode": "palette-classic" }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "title": "추천 생성 응답 시간 (p50 / p95 / p99)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, rate(recommendation_latency_seconds_bucket[5m]))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, rate(recommendation_latency_seconds_bucket[5m]))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(recommendation_latency_seconds_bucket[5m]))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "palette-classic" }
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Redis 캐시 히트율",
+      "type": "gauge",
+      "gridPos": { "x": 0, "y": 8, "w": 8, "h": 8 },
+      "targets": [
+        {
+          "expr": "rate(redis_cache_hits_total[5m]) / (rate(redis_cache_hits_total[5m]) + rate(redis_cache_misses_total[5m])) * 100",
+          "legendFormat": "Cache Hit Rate",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "steps": [
+              { "color": "red", "value": 0 },
+              { "color": "yellow", "value": 50 },
+              { "color": "green", "value": 80 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      }
+    },
+    {
+      "id": 4,
+      "title": "Redis 캐시 히트 / 미스",
+      "type": "timeseries",
+      "gridPos": { "x": 8, "y": 8, "w": 8, "h": 8 },
+      "targets": [
+        {
+          "expr": "rate(redis_cache_hits_total[5m])",
+          "legendFormat": "Hit",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(redis_cache_misses_total[5m])",
+          "legendFormat": "Miss",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": { "mode": "palette-classic" }
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "평점 CRUD 오퍼레이션",
+      "type": "timeseries",
+      "gridPos": { "x": 16, "y": 8, "w": 8, "h": 8 },
+      "targets": [
+        {
+          "expr": "rate(rating_operations_total[5m])",
+          "legendFormat": "{{ operation }}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": { "mode": "palette-classic" }
+        }
+      }
+    },
+    {
+      "id": 6,
+      "title": "전체 API 응답 시간 (p95)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m]))",
+          "legendFormat": "{{ method }} {{ path }}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "palette-classic" }
+        }
+      }
+    },
+    {
+      "id": 7,
+      "title": "전체 API 요청 수",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "rate(http_requests_total[5m])",
+          "legendFormat": "{{ method }} {{ path }} {{ status_code }}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": { "mode": "palette-classic" }
+        }
+      }
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/dashboards_provision.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards_provision.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: "bob_dashboards"
+    orgId: 1
+    folder: "Bob_Movie"
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /etc/grafana/dashboards
+      

--- a/monitoring/grafana/provisioning/datasources/datasources.yml
+++ b/monitoring/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+    

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: "bob_app"
+    static_configs:
+      - targets: ["app:8000"]
+    metrics_path: "/metrics"

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,5 @@ torch==2.1.0
 torchvision==0.16.0
 # bcrypt 버전 고정
 bcrypt==4.0.1
+# prometheus client 0.24.1
+prometheus-client==0.24.1


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #31 

## 📝 변경 내용

### 주요 변경사항
- /metrics 엔드포인트
- 추천 전략 별 요청 카운터 + latency 히스토그램
- Redis 캐시 히트/미스 카운터
- 평점 CRUD 카운터 (생성/수정/삭제)

- docker-compose에 prometheus, grafana container 추가
- 대시보드 자동 provisioning (재시작 시 유지)
- 7개 패널: 추천 요청 수, 응답 시간, 캐시 히트율, 캐시 히트,/미스, 평점 오퍼레이션, 전체 API 응답시간/요청 수 등

## 🧪 테스트 결과
```bash
# 확인
Grafana: localhost:3000
Prometheus: localhost:9090
```

## ✅ 체크리스트
- [X] 로컬 테스트 완료
- [x] 코드 자체 리뷰 완료
- [ ] 문서 업데이트 (필요시)
- [X] 대시보드 데이터 수집 확인

## 💬 추가 설명
